### PR TITLE
feat: Make cmd+9 open last tab (not the 9th tab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@
 <p>The "Tab-Jumper" extension allows you to easily jump to a specific VSCode tab or tab group and move tabs/tab groups around with different commands</p>
 
 # Commands
-### Jump to tabs 1 through 9 in a tab group
+### Jump to tabs 1 through 8 in a tab group
 <ul>
     <li>cmd+(tab number)</li>
+</ul>
+
+### Jump to the last tab
+<ul>
+    <li>cmd+9</li>
 </ul>
 
 ### Jump to tab groups 1 through 8

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 			},
 			{
 				"key": "cmd+9",
-				"command": "workbench.action.openEditorAtIndex9"
+				"command": "workbench.action.lastEditorInGroup"
 			},
 			{
 				"key": "alt+cmd+1",


### PR DESCRIPTION
This keeps it in sync in some what other apps are doing, e.g. Google Chrome. 

More information about it [here](https://stackoverflow.com/questions/39245966/vs-code-possible-to-switch-tabs-files-with-cmdnumbers#comment80938529_41112036) and [here](https://stackoverflow.com/questions/41951206/visual-studio-code-go-to-a-tab-by-number#comment84458277_43456262).