### PR TITLE
feat: Change move command shortcuts so they don't interfere with VS Code defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,30 +17,30 @@
 # Commands
 ### Jump to tabs 1 through 9 in a tab group
 <ul>
-    <li>cmd+(tab number)</li>
+    <li>CMD + (tab number)</li>
 </ul>
 
 ### Jump to tab groups 1 through 8
 <ul>
-    <li>alt (option)+cmd+(tab number)</li>
+    <li>OPTION + CMD + (tab number)</li>
 </ul>
 
 ### Move the active tab left in the active tab group
 <ul>
-    <li>shift+cmd+o</li>
+    <li>SHIFT + CONTROL + CMD + [</li>
 </ul>
 
 ### Move the active tab right in the active tab group
 <ul>
-    <li>shift+cmd+p</li>
+    <li>SHIFT + CONTROL + CMD + ]</li>
 </ul>
 
 ### Move the active tab group left
 <ul>
-    <li>alt (option)+cmd+o</li>
+    <li>SHIFT + OPTION + CMD + [</li>
 </ul>
 
 ### Move the active tab group right
 <ul>
-    <li>alt (option)+cmd+p</li>
+    <li>SHIFT + OPTION + CMD + ]</li>
 </ul>

--- a/package.json
+++ b/package.json
@@ -86,19 +86,19 @@
 				"command": "workbench.action.focusEighthEditorGroup"
 			},
 			{
-				"key": "shift+cmd+o",
+				"key": "ctrl+shift+meta+[BracketLeft]",
 				"command": "workbench.action.moveEditorLeftInGroup"
 			},
 			{
-				"key": "shift+cmd+p",
+				"key": "ctrl+shift+meta+[BracketRight]",
 				"command": "workbench.action.moveEditorRightInGroup"
 			},
 			{
-				"key": "alt+cmd+o",
+				"key": "shift+alt+meta+[BracketLeft]",
 				"command": "workbench.action.moveActiveEditorGroupLeft"
 			},
 			{
-				"key": "alt+cmd+p",
+				"key": "shift+alt+meta+[BracketRight]",
 				"command": "workbench.action.moveActiveEditorGroupRight"
 			}
 		]


### PR DESCRIPTION
CMD+SHIFT+P is a very popular and useful keyboard shortcut for Command Palette. I propose we don't replace it as it's a default in many apps, not just VS Code (e.g. Google Chrome).

Instead we could do:

- move a tab left `CMD + SHIFT + CONTROL + [` (inspired by `CMD + SHIFT + [` which navigates to previous tab in most of the apps, including VS Code)
- move a tab right `CMD + SHIFT + CONTROL + ]`
- move a tabs group left `CMD + SHIFT + OPTION + [`
- move a tabs group right `CMD + SHIFT + OPTION + ]`
